### PR TITLE
Fixed classmap detection

### DIFF
--- a/zray.php
+++ b/zray.php
@@ -1,47 +1,77 @@
 <?php
-
 namespace ZRay;
 
-class Composer {
-	public function findFileWithExtensionExit($context, &$storage)
-	{
-		$storage['classMap'][] = array(
-						'class' => $context['functionArgs'][0],
-						'filename' => str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $context['returnValue']));
-	}
+use ZRayExtension;
+
+class Composer
+{
+    public function findFileWithExtensionExit($context, &$storage)
+    {
+        if ($context['returnValue'] === null) {
+            // failed lookup, so class was not in Composer class map
+            return;
+        }
+
+        $storage['classMap'][] = [
+            'class'    => $context['functionArgs'][0],
+            'filename' => str_replace(
+                ['/', '\\'],
+                DIRECTORY_SEPARATOR,
+                $context['returnValue']
+            )
+        ];
+    }
 
 
-	public function registerExit($context, &$storage)
-	{
-		$composerDir = dirname($context['calledFromFile']);
-		$json = file_get_contents($composerDir.'/installed.json');
-		$data = json_decode($json);
-		foreach ($data as $package) {
-			$entry = [
-				'name'    => $package->name,
-				'version' => $package->version,
-				'source'  => (isset($package->source) && isset($package->source->url)) ? $package->source->url : '',
-			];
-			$entry['requires'] = (empty($package->require) ? array() : (array) $package->require);
-			if (!empty($package->authors)) {
-				$entry['authors'] = $package->authors;
-			}
-			if (!empty($package->homepage)) {
-				$entry['homepage'] = $package->homepage;
-			}
-			$storage['packages'][$package->name] = $entry;
-		}
-	}
+    public function registerExit($context, &$storage)
+    {
+        $composerDir = dirname($context['calledFromFile']);
+        $json        = file_get_contents($composerDir.'/installed.json');
+        $data        = json_decode($json);
+
+        foreach ($data as $package) {
+            $source = (isset($package->source) && isset($package->source->url))
+                ? $package->source->url
+                : '';
+
+            $entry = [
+                'name'    => $package->name,
+                'version' => $package->version,
+                'source'  => $source,
+            ];
+
+            $entry['requires'] = (empty($package->require) ? [] : (array) $package->require);
+
+            if (! empty($package->authors)) {
+                $entry['authors'] = $package->authors;
+            }
+
+            if (! empty($package->homepage)) {
+                $entry['homepage'] = $package->homepage;
+            }
+
+            $storage['packages'][$package->name] = $entry;
+        }
+    }
 }
 
-$zre = new \ZRayExtension("composer");
+$extension = new ZRayExtension("composer");
+$composer  = new Composer();
 
-$zrayComposer = new Composer();
-
-$zre->setMetadata(array(
-	'logo' => __DIR__ . DIRECTORY_SEPARATOR . 'logo.png',
+$extension->setMetadata(array(
+    'logo' => __DIR__ . DIRECTORY_SEPARATOR . 'logo.png',
 ));
 
-$zre->setEnabledAfter('Composer\Autoload\ClassLoader::register');
-$zre->traceFunction('Composer\Autoload\ClassLoader::register', function(){}, array($zrayComposer, 'registerExit'));
-$zre->traceFunction('Composer\Autoload\ClassLoader::findFileWithExtension', function(){}, array($zrayComposer, 'findFileWithExtensionExit'));
+$extension->setEnabledAfter('Composer\Autoload\ClassLoader::register');
+$extension->traceFunction(
+    'Composer\Autoload\ClassLoader::register',
+    function() {
+    },
+    [$composer, 'registerExit']
+);
+$extension->traceFunction(
+    'Composer\Autoload\ClassLoader::findFileWithExtension',
+    function() {
+    },
+    [$composer, 'findFileWithExtensionExit']
+);


### PR DESCRIPTION
Previously, any class that Composer passed to its `findFileWithExtension` method
was listed in the Composer classmap details. However, this was incorrect; later
autoloaders -- such as ZF's -- might be able to handle the given class.

Composer communicates a class miss with a null value; this patch detects that
null value and returns early in such situations, preventing invalid additions to
the classmap details.

Additionally, this has been cleaned up to follow PSR-1/PSR-2 and for internal
consistency (originally there was a mix of `array()` and `[]` usage; not it uses
solely `[]` -- since Z-Ray is only present on systems running PHP 5.4+ anyways).
