### PR TITLE
Exit function if JSON file does not exist

### DIFF
--- a/zray.php
+++ b/zray.php
@@ -29,8 +29,14 @@ class Composer
 
     public function registerExit($context, &$storage)
     {
-        $composerDir = dirname($context['calledFromFile']);
-        $json        = file_get_contents($composerDir.'/installed.json');
+    	$composerDir = dirname($context['calledFromFile']);
+        $jsonFile    = $composerDir.'/installed.json';
+
+        if (file_exists($jsonFile) || !is_readable($jsonFile)) {
+            return false;
+        }
+
+        $json        = file_get_contents($jsonFile);
         $data        = json_decode($json);
 
         foreach ($data as $package) {


### PR DESCRIPTION
The Composer Z-Ray extension generated PHP warnings in a site where Composer packages were indeed used, however the `installed.json` file was missing. This patch simply skips things when the JSON file is not there.